### PR TITLE
feat: Ukiyo-e visual redesign with /contact route

### DIFF
--- a/docs/superpowers/plans/2026-04-19-ukiyo-e-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-ukiyo-e-redesign.md
@@ -1,0 +1,939 @@
+# Ukiyo-e Visual Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the existing warm earthy design system with the Ukiyo-e-inspired navy/ocean palette, SVG wave decorations, frosted glass cards, and asymmetric layouts — while preserving all data and adding a /contact route.
+
+**Architecture:** Shell-first — update global CSS tokens and Layout/Navigation first, then restyle each page component independently. A new ContactPage component is added and wired into App.tsx. No data files are modified.
+
+**Tech Stack:** React 18, TypeScript, Tailwind CSS v4, Vite, React Router v6
+
+---
+
+## File Map
+
+| File | Action |
+|---|---|
+| `src/index.css` | Update CSS variables, paper texture, remove floatSlow |
+| `src/components/Layout.tsx` | Rebuild: waves, crest orbs, paper texture, new container |
+| `src/components/Navigation.tsx` | Rebuild: brand block, new link style, add Contact |
+| `src/components/Home.tsx` | Rebuild: hero grid, decorative SVG card, frosted ventures |
+| `src/components/ExperiencePage.tsx` | Restyle: new section headers, frosted cards, dark CEO card |
+| `src/components/SkillsPage.tsx` | Restyle: frosted highlights, pill tags, section headers |
+| `src/components/ContactPage.tsx` | Create: new contact page component |
+| `src/App.tsx` | Add /contact route, remove contactItems from Home |
+
+> **Note:** This project has no automated test suite. Verification is done visually via `npm run dev`. Each task ends with a dev server check and a commit.
+
+---
+
+## Task 1: Update CSS design tokens and global styles
+
+**Files:**
+- Modify: `src/index.css`
+
+- [ ] **Step 1: Update CSS variables and remove floatSlow**
+
+Replace the entire contents of `src/index.css` with:
+
+```css
+@import "tailwindcss";
+
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg: #F2F1F0;
+  --ink: #063C6B;
+  --muted: rgba(6, 60, 107, 0.60);
+  --accent: #F07A20;
+  --accent-2: #6FA3C2;
+  --border: rgba(6, 60, 107, 0.10);
+  --shadow: 0 12px 40px rgba(6, 60, 107, 0.05);
+}
+
+body {
+  font-family: 'Space Grotesk', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background-color: #F2F1F0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.font-display {
+  font-family: 'Fraunces', 'Times New Roman', serif;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-up {
+  animation: fadeUp 0.9s ease both;
+}
+
+@media print {
+  :root {
+    --bg: #ffffff;
+    --ink: #111111;
+    --muted: #333333;
+    --accent: #000000;
+    --accent-2: #000000;
+    --border: rgba(0, 0, 0, 0.18);
+    --shadow: none;
+  }
+
+  * {
+    animation: none !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    background: transparent !important;
+    opacity: 1 !important;
+    color: #000000 !important;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  main {
+    padding: 0 !important;
+  }
+
+  header,
+  section,
+  footer {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  header {
+    display: none !important;
+  }
+
+  .print-only {
+    break-after: avoid-page;
+    page-break-after: avoid;
+  }
+
+  .min-h-screen {
+    min-height: auto !important;
+  }
+
+  a {
+    color: #000000 !important;
+    text-decoration: none !important;
+  }
+
+  .animate-fade-up {
+    animation: none !important;
+  }
+
+  .backdrop-blur {
+    backdrop-filter: none !important;
+  }
+
+  .grid {
+    display: block !important;
+  }
+
+  .gap-10,
+  .gap-6,
+  .gap-5 {
+    gap: 0.75rem !important;
+  }
+
+  .space-y-10 > :not([hidden]) ~ :not([hidden]),
+  .space-y-6 > :not([hidden]) ~ :not([hidden]),
+  .space-y-5 > :not([hidden]) ~ :not([hidden]) {
+    margin-top: 0.75rem !important;
+  }
+
+  .rounded-3xl,
+  .rounded-2xl,
+  .rounded-full {
+    border-radius: 0 !important;
+  }
+
+  [class*="border"] {
+    border: none !important;
+  }
+
+  .screen-only {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+}
+
+.print-only {
+  display: none;
+}
+```
+
+- [ ] **Step 2: Run dev server and verify background is #F2F1F0**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:5173`. The page background should be a light warm gray (`#F2F1F0`). The accent colors won't be visible yet since component classes still reference old values — that's expected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.css
+git commit -m "feat: update design tokens to Ukiyo-e palette"
+```
+
+---
+
+## Task 2: Rebuild Layout.tsx — shell with waves, orbs, paper texture
+
+**Files:**
+- Modify: `src/components/Layout.tsx`
+
+- [ ] **Step 1: Replace Layout.tsx**
+
+```tsx
+import React from 'react';
+import Footer from './Footer/Footer';
+import Navigation from './Navigation';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+function Layout({ children }: LayoutProps) {
+  return (
+    <div className="min-h-screen bg-[#F2F1F0] text-[#063C6B] selection:bg-[#F07A20] selection:text-white">
+      <div className="relative overflow-hidden">
+        {/* Paper texture */}
+        <div className="pointer-events-none absolute inset-0 opacity-[0.05] mix-blend-multiply [background-image:radial-gradient(rgba(6,60,107,0.65)_0.7px,transparent_0.7px)] [background-size:12px_12px]" />
+
+        {/* Wave lines */}
+        <svg
+          className="pointer-events-none absolute left-0 top-0 h-[520px] w-full opacity-[0.14]"
+          viewBox="0 0 1440 520"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="none"
+        >
+          <path d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176" stroke="#063C6B" strokeWidth="1.5" />
+          <path d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285" stroke="#6FA3C2" strokeWidth="1.2" />
+          <path d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339" stroke="#063C6B" strokeWidth="1" />
+        </svg>
+
+        {/* Crest orbs */}
+        <div className="pointer-events-none absolute right-[-8rem] top-24 h-[32rem] w-[32rem] rounded-[42%] border border-[#063C6B]/12 bg-[#6FA3C2]/14 blur-[1px]" />
+        <div className="pointer-events-none absolute right-[2rem] top-16 h-[22rem] w-[22rem] rounded-[45%] border border-[#063C6B]/10 bg-white/30" />
+
+        <Navigation />
+
+        <main className="relative mx-auto max-w-6xl px-6 py-8 md:px-10 md:py-10">
+          {children}
+        </main>
+      </div>
+      <Footer />
+    </div>
+  );
+}
+
+export default Layout;
+```
+
+- [ ] **Step 2: Verify in browser**
+
+With `npm run dev` still running, reload `http://localhost:5173`. You should see:
+- Light `#F2F1F0` background
+- Faint dot texture across the page
+- Three SVG wave lines visible in the upper portion of the page
+- Two soft rounded blob shapes in the top-right corner
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Layout.tsx
+git commit -m "feat: rebuild Layout with Ukiyo-e waves, orbs, paper texture"
+```
+
+---
+
+## Task 3: Rebuild Navigation.tsx
+
+**Files:**
+- Modify: `src/components/Navigation.tsx`
+
+- [ ] **Step 1: Replace Navigation.tsx**
+
+```tsx
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function Navigation() {
+  return (
+    <nav className="relative z-50 px-6 md:px-10">
+      <div className="mx-auto flex max-w-6xl items-center justify-between border-b border-[#063C6B]/10 pb-5 pt-8">
+        <Link to="/" className="group">
+          <div className="font-medium text-sm tracking-[0.24em] uppercase text-[#063C6B]/85">JMSALCIDO</div>
+          <div className="mt-1 text-xs tracking-[0.16em] uppercase text-[#063C6B]/45">software · systems · operations</div>
+        </Link>
+        <ul className="hidden md:flex gap-8 text-sm text-[#063C6B]/68">
+          <li>
+            <Link to="/" className="transition hover:text-[#F07A20]">Home</Link>
+          </li>
+          <li>
+            <Link to="/experience" className="transition hover:text-[#F07A20]">Experience</Link>
+          </li>
+          <li>
+            <Link to="/skills" className="transition hover:text-[#F07A20]">Skills</Link>
+          </li>
+          <li>
+            <Link to="/contact" className="transition hover:text-[#F07A20]">Contact</Link>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}
+
+export default Navigation;
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Reload. The nav should now show:
+- "JMSALCIDO" in navy with wide letter spacing
+- Sub-label "software · systems · operations" below in muted navy
+- Links: Home / Experience / Skills / Contact — navy tinted, orange on hover
+- No white background pill — transparent over the wave/paper shell
+- Links are hidden on mobile (visible at `md:` breakpoint and up)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Navigation.tsx
+git commit -m "feat: rebuild Navigation with Ukiyo-e style and Contact link"
+```
+
+---
+
+## Task 4: Rebuild Home.tsx
+
+**Files:**
+- Modify: `src/components/Home.tsx`
+
+The `contactItems` prop is removed — the contact card is replaced by a decorative SVG. The Contact page handles contact info now.
+
+- [ ] **Step 1: Replace Home.tsx**
+
+```tsx
+import React from 'react';
+import { Link } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import developer from '../../src/data/developer';
+import resume from '../../src/data/resume';
+
+function Home() {
+  return (
+    <div className="animate-fade-up">
+      {/* Hero */}
+      <section className="relative grid min-h-[78vh] items-center gap-16 py-14 md:grid-cols-[1.1fr_0.9fr] md:py-20">
+        <div className="relative z-10 max-w-3xl">
+          <div className="mb-6 text-xs uppercase tracking-[0.28em] text-[#063C6B]/45">
+            software · systems · operations · automation
+          </div>
+          <h1 className="font-display text-5xl leading-[0.94] tracking-[-0.045em] md:text-7xl lg:text-[5.6rem]">
+            {resume.headline.split(',')[0]}
+          </h1>
+          <p className="mt-8 max-w-2xl text-base leading-8 text-[#063C6B]/72 md:text-lg">
+            {resume.summary}
+          </p>
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link
+              to="/experience"
+              className="inline-flex items-center rounded-full border border-[#063C6B]/18 bg-white/60 px-6 py-3 text-sm text-[#063C6B] backdrop-blur-sm transition hover:border-[#F07A20]/50 hover:text-[#F07A20]"
+            >
+              View experience
+            </Link>
+            <Link
+              to="/contact"
+              className="inline-flex items-center rounded-full border border-[#063C6B] bg-[#063C6B] px-6 py-3 text-sm text-[#F2F1F0] transition hover:bg-[#0C4A80]"
+            >
+              Get in touch
+            </Link>
+          </div>
+        </div>
+
+        {/* Decorative SVG art card */}
+        <div className="relative mx-auto w-full max-w-[30rem]">
+          <div className="absolute -left-10 top-10 h-[24rem] w-[24rem] rounded-[48%] border border-[#063C6B]/10 bg-[#6FA3C2]/10" />
+          <div className="relative overflow-hidden rounded-[2.5rem] border border-[#063C6B]/10 bg-white/60 shadow-[0_24px_80px_rgba(6,60,107,0.08)] backdrop-blur-sm">
+            <div className="aspect-[4/5] w-full bg-[linear-gradient(180deg,rgba(255,255,255,0.75),rgba(255,255,255,0.45))]">
+              <svg className="h-full w-full" viewBox="0 0 520 650" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M-40 405C58 375 104 328 175 328C238 328 271 365 320 365C377 365 409 322 468 322C527 322 578 373 635 392" stroke="#063C6B" strokeWidth="2" />
+                <path d="M-30 442C76 413 123 382 195 382C264 382 302 427 356 427C416 427 448 385 504 385C560 385 602 420 655 445" stroke="#6FA3C2" strokeWidth="2" />
+                <path d="M250 132C284 122 315 133 340 164C364 194 364 226 344 259C325 289 296 307 258 312" stroke="#063C6B" strokeWidth="2" />
+                <path d="M205 312C220 281 251 257 289 250C336 242 381 258 415 301C449 344 453 392 427 443" stroke="#063C6B" strokeWidth="2" />
+                <path d="M85 459C127 422 168 404 208 404C257 404 304 430 347 482" stroke="#063C6B" strokeWidth="1.5" />
+                <path d="M300 130C344 86 404 77 453 111C503 146 515 205 487 266" stroke="#6FA3C2" strokeWidth="1.5" />
+                <circle cx="392" cy="142" r="32" fill="#F2F1F0" stroke="#063C6B" strokeWidth="1.2" />
+              </svg>
+              <div className="absolute left-6 top-6 text-[11px] uppercase tracking-[0.28em] text-[#063C6B]/45">Systems in motion</div>
+              <div className="absolute bottom-6 left-6 max-w-[15rem] text-sm leading-6 text-[#063C6B]/58">
+                {developer.profile.name} · {new Date().getFullYear()}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Profile summary */}
+      <section className="relative mt-4 grid gap-10 md:grid-cols-[0.95fr_1.05fr] md:gap-14">
+        <div className="relative border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Profile</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">
+            Built at the intersection of craft and systems.
+          </h2>
+        </div>
+        <div className="relative border-t border-[#063C6B]/12 pt-8 text-[#063C6B]/72">
+          <div className="max-w-2xl text-base leading-8">
+            <ReactMarkdown>{resume.summary}</ReactMarkdown>
+          </div>
+          <div className="mt-8 grid gap-3 sm:grid-cols-2">
+            {resume.focusAreas.map((item: string) => (
+              <div key={item} className="rounded-2xl border border-[#063C6B]/10 bg-white/55 px-4 py-4 text-sm backdrop-blur-sm">
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Ventures */}
+      <section className="mt-24">
+        <div className="flex items-end justify-between gap-8 border-b border-[#063C6B]/10 pb-4">
+          <div>
+            <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Ventures & Community</div>
+            <h2 className="mt-3 font-display text-3xl tracking-[-0.04em] md:text-5xl">Projects arranged in flow.</h2>
+          </div>
+          <div className="hidden text-sm text-[#063C6B]/42 md:block">community · craft · culture</div>
+        </div>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-6">
+            {resume.ventures.items.slice(0, 2).map((item, idx) => (
+              <a
+                key={item.name}
+                href={item.url}
+                target="_blank"
+                rel="noreferrer"
+                className={`block rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm transition hover:-translate-y-1 hover:border-[#F07A20]/30 ${idx === 1 ? 'md:ml-10' : ''}`}
+              >
+                <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.description.split(' ').slice(0, 3).join(' ')}</div>
+                <h3 className="mt-3 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.name}</h3>
+                <p className="mt-4 max-w-2xl text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+              </a>
+            ))}
+          </div>
+          <div className="md:pt-14">
+            {resume.ventures.items.slice(2).map((item, idx) => (
+              <a
+                key={item.name}
+                href={item.url}
+                target="_blank"
+                rel="noreferrer"
+                className={`block rounded-[2rem] border border-[#063C6B]/10 p-7 shadow-[0_18px_56px_rgba(6,60,107,0.12)] transition hover:-translate-y-1 ${idx === 0 ? 'bg-[#063C6B] text-[#F2F1F0]' : 'bg-white/60 backdrop-blur-sm mt-6'}`}
+              >
+                <div className={`text-xs uppercase tracking-[0.22em] ${idx === 0 ? 'text-[#CFD3D2]/70' : 'text-[#063C6B]/42'}`}>
+                  {item.description.split(' ').slice(0, 3).join(' ')}
+                </div>
+                <h3 className="mt-3 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.name}</h3>
+                <p className={`mt-4 text-sm leading-7 ${idx === 0 ? 'text-[#CFD3D2]' : 'text-[#063C6B]/72'}`}>{item.description}</p>
+                {idx === 0 && <div className="mt-8 h-px w-20 bg-[#6FA3C2]/45" />}
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Home;
+```
+
+- [ ] **Step 2: Update App.tsx to remove contactItems from Home**
+
+In `src/App.tsx`, find the Home route and remove the `contactItems` prop:
+
+```tsx
+<Route 
+  path="/" 
+  element={<Home />} 
+/>
+```
+
+Also remove the `contactItems` array from the `App` function body (it will be rebuilt in Task 7).
+
+- [ ] **Step 3: Verify in browser**
+
+Reload `http://localhost:5173`. Check:
+- Hero: two-column layout with headline on left, SVG art card on right
+- "View experience" and "Get in touch" CTA buttons (rounded pill, outlined and filled)
+- Profile summary section below with two-column split
+- Ventures grid: first two ventures left-column (second offset right), third venue dark navy, fourth light
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Home.tsx src/App.tsx
+git commit -m "feat: rebuild Home with Ukiyo-e hero, SVG card, frosted ventures"
+```
+
+---
+
+## Task 5: Restyle ExperiencePage.tsx
+
+**Files:**
+- Modify: `src/components/ExperiencePage.tsx`
+
+- [ ] **Step 1: Replace ExperiencePage.tsx**
+
+```tsx
+import React from 'react';
+import { Experience as ExperienceType } from '../../src/data/resume';
+
+interface ExperiencePageProps {
+  leadership: ExperienceType[];
+  softwareEngineering: ExperienceType[];
+}
+
+function ExperiencePage({ leadership, softwareEngineering }: ExperiencePageProps) {
+  return (
+    <div className="animate-fade-up space-y-24 pb-10">
+      {/* Business & Leadership */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Business & Roaster Leadership</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">Directing with craft and discipline.</h2>
+        </div>
+        <div className="mt-10 space-y-6">
+          {leadership.map((item, index) => (
+            <article
+              key={index}
+              className="rounded-[2rem] border border-[#063C6B]/10 bg-[#063C6B] p-7 text-[#F2F1F0] shadow-[0_18px_56px_rgba(6,60,107,0.12)]"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <div className="text-xs uppercase tracking-[0.22em] text-[#CFD3D2]/70">{item.company} · {item.location}</div>
+                  <h3 className="mt-2 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.position}</h3>
+                </div>
+                <span className="text-xs uppercase tracking-[0.22em] text-[#CFD3D2]/70">{item.time}</span>
+              </div>
+              <p className="mt-5 text-sm leading-7 text-[#CFD3D2]">{item.description}</p>
+              {item.description_extra && (
+                <>
+                  <div className="mt-6 h-px w-20 bg-[#6FA3C2]/45" />
+                  <p className="mt-5 text-sm leading-7 text-[#CFD3D2]/88">{item.description_extra}</p>
+                </>
+              )}
+              {item.technologies && item.technologies.length > 0 && (
+                <div className="mt-6 flex flex-wrap gap-2">
+                  {item.technologies.map((tech) => (
+                    <span key={tech} className="rounded-full border border-[#6FA3C2]/30 px-3 py-1 text-xs text-[#CFD3D2]/80">
+                      {tech}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Software Engineering */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Software Engineering</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">A decade of systems thinking.</h2>
+        </div>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-6">
+            {softwareEngineering.filter((_, i) => i % 2 === 0).map((item, index) => (
+              <article
+                key={index}
+                className={`rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm ${index > 0 ? 'md:ml-10' : ''}`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.company} · {item.location}</div>
+                    <h3 className="mt-2 font-display text-2xl tracking-[-0.03em]">{item.position}</h3>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.time}</span>
+                </div>
+                <p className="mt-5 text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+                {item.description_extra && (
+                  <p className="mt-3 text-sm leading-7 text-[#063C6B]/60">{item.description_extra}</p>
+                )}
+                {item.technologies && item.technologies.length > 0 && (
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {item.technologies.map((tech) => (
+                      <span key={tech} className="rounded-full border border-[#063C6B]/10 px-3 py-1 text-xs text-[#063C6B]/70">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+          <div className="space-y-6 md:pt-14">
+            {softwareEngineering.filter((_, i) => i % 2 === 1).map((item, index) => (
+              <article
+                key={index}
+                className="rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.company} · {item.location}</div>
+                    <h3 className="mt-2 font-display text-2xl tracking-[-0.03em]">{item.position}</h3>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.time}</span>
+                </div>
+                <p className="mt-5 text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+                {item.description_extra && (
+                  <p className="mt-3 text-sm leading-7 text-[#063C6B]/60">{item.description_extra}</p>
+                )}
+                {item.technologies && item.technologies.length > 0 && (
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {item.technologies.map((tech) => (
+                      <span key={tech} className="rounded-full border border-[#063C6B]/10 px-3 py-1 text-xs text-[#063C6B]/70">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default ExperiencePage;
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Navigate to `http://localhost:5173/experience`. Check:
+- "Business & Roaster Leadership" section: eyebrow label + serif h2 + dark navy card for CEO role
+- "Software Engineering" section: eyebrow + serif h2 + two-column asymmetric frosted glass cards
+- Technology tags: small bordered pills inside each card
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ExperiencePage.tsx
+git commit -m "feat: restyle ExperiencePage with Ukiyo-e frosted cards and asymmetric grid"
+```
+
+---
+
+## Task 6: Restyle SkillsPage.tsx
+
+**Files:**
+- Modify: `src/components/SkillsPage.tsx`
+
+- [ ] **Step 1: Replace SkillsPage.tsx**
+
+```tsx
+import React from 'react';
+import { Skill } from '../../src/data/resume';
+
+interface SkillsPageProps {
+  skillItems: Skill[];
+  highlights?: string[];
+  languages?: { name: string; level: string }[];
+  interests?: string[];
+}
+
+function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPageProps) {
+  return (
+    <div className="animate-fade-up space-y-24 pb-10">
+      {/* Highlights */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Signature Strengths</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">Discipline below the surface.</h2>
+        </div>
+        <div className="mt-10 grid gap-6 md:grid-cols-2">
+          {highlights?.map((highlight, index) => (
+            <article
+              key={index}
+              className={`rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm ${index === 1 ? 'md:mt-10' : ''}`}
+            >
+              <p className="text-sm leading-7 text-[#063C6B]/72">{highlight}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* Skills */}
+      <section className="grid gap-10 md:grid-cols-[0.86fr_1.14fr]">
+        <div className="border-t border-[#063C6B]/10 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Skills Blend</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">The stack beneath the work.</h2>
+          <p className="mt-5 max-w-md text-base leading-8 text-[#063C6B]/72">
+            Tools and disciplines used across business, product, and engineering contexts.
+          </p>
+        </div>
+        <div className="rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-2">
+            {skillItems.map((skill) => (
+              <div
+                key={skill.name}
+                className="rounded-2xl border border-[#063C6B]/10 px-4 py-4 text-center text-sm text-[#063C6B]/80"
+              >
+                {skill.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Languages & Interests */}
+      <section className="grid gap-10 md:grid-cols-[0.95fr_1.05fr]">
+        <div className="border-t border-[#063C6B]/10 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Languages & Interests</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-4xl">Beyond the screen.</h2>
+        </div>
+        <div className="border-t border-[#063C6B]/10 pt-8 space-y-8">
+          {languages && languages.length > 0 && (
+            <div>
+              <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42 mb-4">Languages</div>
+              <ul className="space-y-3">
+                {languages.map((lang, index) => (
+                  <li key={index} className="flex justify-between items-center border-b border-[#063C6B]/10 pb-3 text-sm text-[#063C6B]/80">
+                    <span>{lang.name}</span>
+                    <span className="text-xs uppercase tracking-[0.18em] text-[#063C6B]/42">{lang.level}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {interests && interests.length > 0 && (
+            <div>
+              <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42 mb-4">Interests</div>
+              <div className="grid grid-cols-2 gap-3">
+                {interests.map((interest, index) => (
+                  <div key={index} className="rounded-2xl border border-[#063C6B]/10 px-4 py-3 text-sm text-[#063C6B]/80">
+                    {interest}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default SkillsPage;
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Navigate to `http://localhost:5173/skills`. Check:
+- "Signature Strengths": two frosted glass cards in a grid, second card offset
+- "Skills Blend": left text column + right grid of bordered pill boxes
+- "Languages & Interests": two-column layout, language rows with border-bottom, interests as bordered pills
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SkillsPage.tsx
+git commit -m "feat: restyle SkillsPage with Ukiyo-e card and pill patterns"
+```
+
+---
+
+## Task 7: Create ContactPage.tsx and wire into App.tsx
+
+**Files:**
+- Create: `src/components/ContactPage.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Create src/components/ContactPage.tsx**
+
+```tsx
+import React from 'react';
+
+interface ContactPageProps {
+  email: string;
+  linkedin: string;
+  github: string;
+}
+
+function ContactPage({ email, linkedin, github }: ContactPageProps) {
+  return (
+    <div className="animate-fade-up pb-10 pt-10">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[#063C6B]/10" />
+      <div className="grid gap-8 md:grid-cols-[1.1fr_0.9fr] md:items-end">
+        <div>
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Contact</div>
+          <h1 className="mt-4 font-display text-4xl tracking-[-0.045em] md:text-6xl">
+            Build something with structure and breath.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-8 text-[#063C6B]/72">
+            Software, systems, workflow design, and products that need engineering judgment without losing aesthetic discipline.
+          </p>
+        </div>
+        <div className="flex flex-col gap-4 md:justify-self-end">
+          <a
+            href={`mailto:${email}`}
+            className="inline-flex items-center rounded-full border border-[#063C6B] px-6 py-3 text-sm text-[#063C6B] transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            {email}
+          </a>
+          <a
+            href={`https://linkedin.com/in/${linkedin}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-[#063C6B]/40 px-6 py-3 text-sm text-[#063C6B]/80 transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            linkedin.com/in/{linkedin}
+          </a>
+          <a
+            href={`https://github.com/${github}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-[#063C6B]/40 px-6 py-3 text-sm text-[#063C6B]/80 transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            github.com/{github}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ContactPage;
+```
+
+- [ ] **Step 2: Update App.tsx to add /contact route**
+
+Replace the full contents of `src/App.tsx` with:
+
+```tsx
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout';
+import Home from './components/Home';
+import ExperiencePage from './components/ExperiencePage';
+import SkillsPage from './components/SkillsPage';
+import ContactPage from './components/ContactPage';
+import developer from './data/developer';
+import resume from './data/resume';
+
+function App() {
+  return (
+    <Router>
+      <Layout>
+        <Routes>
+          <Route
+            path="/"
+            element={<Home />}
+          />
+          <Route
+            path="/experience"
+            element={<ExperiencePage leadership={resume.leadership} softwareEngineering={resume.softwareTimeline} />}
+          />
+          <Route
+            path="/skills"
+            element={<SkillsPage skillItems={resume.skills} highlights={resume.highlights} languages={developer.languages} interests={developer.interests} />}
+          />
+          <Route
+            path="/contact"
+            element={<ContactPage email={developer.contact.email} linkedin={developer.contact.linkedin} github={developer.contact.github} />}
+          />
+        </Routes>
+      </Layout>
+    </Router>
+  );
+}
+
+export default App;
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Navigate to `http://localhost:5173/contact`. Check:
+- Left column: "Contact" eyebrow, large serif headline, description paragraph
+- Right column: three rounded-full bordered links (email, LinkedIn, GitHub) stacked vertically
+- Orange hover effect on all links
+- Navigation "Contact" link works and routes correctly
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ContactPage.tsx src/App.tsx
+git commit -m "feat: add ContactPage and /contact route"
+```
+
+---
+
+## Task 8: Final cross-page verification
+
+- [ ] **Step 1: Visit all routes and check for regressions**
+
+With `npm run dev` running, visit:
+1. `http://localhost:5173/` — Home: hero, profile, ventures
+2. `http://localhost:5173/experience` — Experience: leadership + software timeline
+3. `http://localhost:5173/skills` — Skills: highlights, skill pills, languages
+4. `http://localhost:5173/contact` — Contact: headline, contact links
+
+Check on each page:
+- Paper dot texture visible
+- SVG wave lines visible in upper area
+- Crest orbs visible top-right
+- Navigation shows all 4 links, orange hover works
+- No console errors in browser DevTools
+- No TypeScript errors in terminal
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors. If errors appear, fix them before proceeding.
+
+- [ ] **Step 3: Build check**
+
+```bash
+npm run build
+```
+
+Expected: `dist/` folder created with no errors. Warnings about bundle size are acceptable.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: complete Ukiyo-e visual redesign"
+```

--- a/docs/superpowers/specs/2026-04-19-ukiyo-e-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-ukiyo-e-redesign-design.md
@@ -1,0 +1,136 @@
+# Ukiyo-e Visual Redesign
+
+**Date:** 2026-04-19  
+**Status:** Approved
+
+## Overview
+
+Apply the Ukiyo-e-inspired design system from the approved mock to the existing multi-page resume site. All existing content and data remain unchanged. A new Contact route is added. The approach is shell-first: rebuild Layout and Navigation, then update each page, then add Contact.
+
+## Design Tokens
+
+Replace all CSS variables in `src/index.css`:
+
+| Token | Value | Replaces |
+|---|---|---|
+| `--bg` | `#F2F1F0` | `--paper` (#f7f1e8) |
+| `--ink` | `#063C6B` | `--ink` (#1e1713) |
+| `--accent` | `#F07A20` | `--accent` (#c7763a) |
+| `--accent-2` | `#6FA3C2` | `--accent-2` (#2f6f6d, was unused) |
+| `--border` | `rgba(6,60,107,0.10)` | `--border` |
+| `--muted` | `rgba(6,60,107,0.60)` | `--muted` (#5f554d) |
+
+Paper texture: absolute `radial-gradient(rgba(6,60,107,0.65) 0.7px, transparent 0.7px)` at `12px 12px` spacing, `opacity-[0.05] mix-blend-multiply`, pointer-events-none, placed in `Layout.tsx`.
+
+Fonts unchanged: Fraunces (serif headings) + Space Grotesk (body).
+
+## Layout Shell (`src/components/Layout.tsx`)
+
+The outer wrapper becomes the visual stage for all pages.
+
+- Background: `bg-[#F2F1F0]`, text `text-[#063C6B]`, selection highlight `selection:bg-[#F07A20] selection:text-white`
+- Paper texture dot overlay (absolute, inset-0, pointer-events-none)
+- SVG wave lines: 3 `<path>` elements (navy + steel blue strokes, width 1–1.5px), absolute top-0 left-0, `h-[520px] w-full opacity-[0.14]`, `preserveAspectRatio="none"`
+- Crest orbs: two absolute right-positioned `div`s with `rounded-[42%]` / `rounded-[45%]`, navy/steel-blue tinted backgrounds at low opacity
+- Remove: existing floating gradient circles (`floatSlow` animation blobs)
+- Content container: `relative mx-auto max-w-6xl px-6 py-8 md:px-10 md:py-10`
+
+## Navigation (`src/components/Navigation.tsx`)
+
+- Layout: `flex items-center justify-between border-b border-[#063C6B]/10 pb-5`
+- Brand block (left):
+  - Primary: `font-medium text-sm tracking-[0.24em] uppercase text-[#063C6B]/85` → "JMSALCIDO"
+  - Sub-label: `text-xs tracking-[0.16em] uppercase text-[#063C6B]/45` → current tagline (short form)
+- Nav links (right, hidden on mobile): Home · Experience · Skills · Contact
+  - `text-sm text-[#063C6B]/68 transition hover:text-[#F07A20]`
+- No background fill — transparent over the paper/wave shell
+
+## Home Page (`src/components/Home.tsx`)
+
+**Hero section** — `min-h-[78vh]`, asymmetric two-column grid `md:grid-cols-[1.1fr_0.9fr]`:
+
+- Left column:
+  - Eyebrow: `text-xs uppercase tracking-[0.28em] text-[#063C6B]/45` — "software · systems · operations · automation"
+  - Headline: `font-serif text-5xl md:text-7xl lg:text-[5.6rem] leading-[0.94] tracking-[-0.045em]` — pulled from `resume.headline`
+  - Summary paragraph: `text-[#063C6B]/72 leading-8`
+  - Two CTA buttons (rounded-full):
+    - Outlined: `border border-[#063C6B]/18 bg-white/60 backdrop-blur-sm hover:border-[#F07A20]/50 hover:text-[#F07A20]` → links to `/experience`
+    - Filled navy: `border border-[#063C6B] bg-[#063C6B] text-[#F2F1F0] hover:bg-[#0C4A80]` → links to `/contact`
+
+- Right column: decorative SVG art card (wave contour lines inside a frosted glass rounded card, matching mock's "Layer study" block). Static SVG, no content.
+
+**Ventures section** — existing ventures data, each card becomes:
+- `rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm`
+- Eyebrow label in `text-xs uppercase tracking-[0.22em] text-[#063C6B]/42`
+- Title in `font-serif`
+
+## Experience Page (`src/components/ExperiencePage.tsx`)
+
+Section headers use the eyebrow + serif heading pattern:
+- Eyebrow: `text-xs uppercase tracking-[0.26em] text-[#063C6B]/42`
+- H2: `font-serif text-3xl md:text-5xl tracking-[-0.04em]`
+- Thin border-top separator: `border-t border-[#063C6B]/12 pt-8`
+
+Each experience card:
+- `rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm`
+- Role title in `font-serif`
+- Company + date in `text-xs uppercase tracking-[0.22em] text-[#063C6B]/42`
+- Description in `text-sm leading-7 text-[#063C6B]/72`
+
+Featured/most-recent role (CEO at Culto al Perro Café): dark navy card — `bg-[#063C6B] text-[#F2F1F0]`, description `text-[#CFD3D2]`, eyebrow `text-[#CFD3D2]/70`.
+
+Layout: two-column asymmetric grid separating Business leadership from Software engineering timeline, with `md:pt-14` offset on the second column for visual flow.
+
+## Skills Page (`src/components/SkillsPage.tsx`)
+
+**Highlights section** — two-column grid, each highlight as a frosted glass card.
+
+**Skill tags** — grid `grid-cols-2 md:grid-cols-4`, each tag:
+- `rounded-2xl border border-[#063C6B]/10 px-4 py-4 text-center text-sm text-[#063C6B]/80`
+- No filled backgrounds — just bordered pills
+
+**Languages & Interests** — simple list, same eyebrow/section pattern.
+
+## Contact Page (`src/components/ContactPage.tsx`) — New
+
+New file and new route `/contact` added to `src/App.tsx`.
+
+Layout: two-column `md:grid-cols-[1.1fr_0.9fr] md:items-end` (matches mock contact section):
+- Left: eyebrow "Contact", large serif headline, brief paragraph
+- Right: contact links as `rounded-full border` buttons:
+  - Email → `mailto:` from `developer.contact.email`
+  - LinkedIn → from `developer.contact.linkedin`
+  - GitHub → from `developer.contact.github`
+  - All use `border-[#063C6B] hover:border-[#F07A20] hover:text-[#F07A20]` treatment
+
+Navigation updated to include Contact link.
+
+## Routing
+
+`src/App.tsx` — add:
+```tsx
+<Route path="/contact" element={<ContactPage developer={developer} />} />
+```
+
+Navigation gets the fourth link: `{ label: 'Contact', path: '/contact' }`.
+
+## What Does NOT Change
+
+- All data files (`src/data/developer.ts`, `src/data/resume.ts`) — untouched
+- Font imports (Fraunces, Space Grotesk)
+- Print styles — preserved, update color values to new tokens
+- Analytics integration
+- Unused legacy components in `MainContent/` and `Sidebar/` — left as-is
+
+## File Change Summary
+
+| File | Action |
+|---|---|
+| `src/index.css` | Update CSS variables, paper texture, remove old animations |
+| `src/components/Layout.tsx` | Rebuild shell with waves, orbs, paper texture |
+| `src/components/Navigation.tsx` | New nav style, add Contact link |
+| `src/components/Home.tsx` | New hero layout, frosted glass venture cards |
+| `src/components/ExperiencePage.tsx` | New card styles, section layout |
+| `src/components/SkillsPage.tsx` | New card/tag styles, section layout |
+| `src/components/ContactPage.tsx` | New file |
+| `src/App.tsx` | Add `/contact` route |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,33 +4,30 @@ import Layout from './components/Layout';
 import Home from './components/Home';
 import ExperiencePage from './components/ExperiencePage';
 import SkillsPage from './components/SkillsPage';
+import ContactPage from './components/ContactPage';
 import developer from './data/developer';
 import resume from './data/resume';
 
 function App() {
-  const contactItems = [
-    { label: 'Email', value: developer.contact.email, href: `mailto:${developer.contact.email}` },
-    { label: 'Phone', value: developer.contact.phone, href: `tel:${developer.contact.phone}` },
-    { label: 'Website', value: developer.contact.website.name, href: developer.contact.website.url },
-    { label: 'LinkedIn', value: developer.contact.linkedin, href: `https://linkedin.com/in/${developer.contact.linkedin}` },
-    { label: 'GitHub', value: developer.contact.github, href: `https://github.com/${developer.contact.github}` }
-  ];
-
   return (
     <Router>
       <Layout>
         <Routes>
-          <Route 
-            path="/" 
-            element={<Home contactItems={contactItems} />} 
+          <Route
+            path="/"
+            element={<Home />}
           />
-<Route 
-  path="/experience" 
-  element={<ExperiencePage leadership={resume.leadership} softwareEngineering={resume.softwareTimeline} />} 
-/>
-          <Route 
-            path="/skills" 
-            element={<SkillsPage skillItems={resume.skills} highlights={resume.highlights} languages={developer.languages} interests={developer.interests} />} 
+          <Route
+            path="/experience"
+            element={<ExperiencePage leadership={resume.leadership} softwareEngineering={resume.softwareTimeline} />}
+          />
+          <Route
+            path="/skills"
+            element={<SkillsPage skillItems={resume.skills} highlights={resume.highlights} languages={developer.languages} interests={developer.interests} />}
+          />
+          <Route
+            path="/contact"
+            element={<ContactPage email={developer.contact.email} linkedin={developer.contact.linkedin} github={developer.contact.github} />}
           />
         </Routes>
       </Layout>

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface ContactPageProps {
+  email: string;
+  linkedin: string;
+  github: string;
+}
+
+function ContactPage({ email, linkedin, github }: ContactPageProps) {
+  return (
+    <div className="animate-fade-up pb-10 pt-10">
+      <div className="grid gap-8 md:grid-cols-[1.1fr_0.9fr] md:items-end">
+        <div>
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Contact</div>
+          <h1 className="mt-4 font-display text-4xl tracking-[-0.045em] md:text-6xl">
+            Build something with structure and breath.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-8 text-[#063C6B]/72">
+            Software, systems, workflow design, and products that need engineering judgment without losing aesthetic discipline.
+          </p>
+        </div>
+        <div className="flex flex-col gap-4 md:justify-self-end">
+          <a
+            href={`mailto:${email}`}
+            className="inline-flex items-center rounded-full border border-[#063C6B] px-6 py-3 text-sm text-[#063C6B] transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            {email}
+          </a>
+          <a
+            href={`https://linkedin.com/in/${linkedin}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-[#063C6B]/40 px-6 py-3 text-sm text-[#063C6B]/80 transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            linkedin.com/in/{linkedin}
+          </a>
+          <a
+            href={`https://github.com/${github}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-[#063C6B]/40 px-6 py-3 text-sm text-[#063C6B]/80 transition hover:border-[#F07A20] hover:text-[#F07A20]"
+          >
+            github.com/{github}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ContactPage;

--- a/src/components/ExperiencePage.tsx
+++ b/src/components/ExperiencePage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Experience as ExperienceType } from '../../src/data/resume';
+import { Experience as ExperienceType } from '../data/resume';
 
 interface ExperiencePageProps {
   leadership: ExperienceType[];
@@ -16,9 +16,9 @@ function ExperiencePage({ leadership, softwareEngineering }: ExperiencePageProps
           <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">Directing with craft and discipline.</h2>
         </div>
         <div className="mt-10 space-y-6">
-          {leadership.map((item, index) => (
+          {leadership.map((item) => (
             <article
-              key={index}
+              key={`${item.company}-${item.position}`}
               className="rounded-[2rem] border border-[#063C6B]/10 bg-[#063C6B] p-7 text-[#F2F1F0] shadow-[0_18px_56px_rgba(6,60,107,0.12)]"
             >
               <div className="flex flex-wrap items-start justify-between gap-4">

--- a/src/components/ExperiencePage.tsx
+++ b/src/components/ExperiencePage.tsx
@@ -8,50 +8,113 @@ interface ExperiencePageProps {
 
 function ExperiencePage({ leadership, softwareEngineering }: ExperiencePageProps) {
   return (
-    <div className="space-y-10 animate-fade-up">
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[var(--muted)]">
-          Business & Roaster Leadership
-        </p>
-        <div className="mt-6 space-y-6">
+    <div className="animate-fade-up space-y-24 pb-10">
+      {/* Business & Leadership */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Business & Roaster Leadership</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">Directing with craft and discipline.</h2>
+        </div>
+        <div className="mt-10 space-y-6">
           {leadership.map((item, index) => (
-            <div key={index} className="rounded-2xl bg-[var(--paper)] p-5">
-              <div className="flex flex-wrap items-center justify-between gap-2">
+            <article
+              key={index}
+              className="rounded-[2rem] border border-[#063C6B]/10 bg-[#063C6B] p-7 text-[#F2F1F0] shadow-[0_18px_56px_rgba(6,60,107,0.12)]"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <h3 className="font-display text-2xl text-[var(--ink)]">{item.position}</h3>
-                  <p className="text-sm text-[var(--muted)]">{item.company} • {item.location}</p>
+                  <div className="text-xs uppercase tracking-[0.22em] text-[#CFD3D2]/70">{item.company} · {item.location}</div>
+                  <h3 className="mt-2 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.position}</h3>
                 </div>
-                <span className="text-xs uppercase tracking-[0.25em] text-[var(--muted)]">{item.time}</span>
+                <span className="text-xs uppercase tracking-[0.22em] text-[#CFD3D2]/70">{item.time}</span>
               </div>
-              <div className="mt-4 space-y-3 text-sm leading-relaxed text-[var(--ink)]">
-                <pre className="whitespace-pre-wrap font-sans">{item.description}</pre>
-                {item.description_extra && <pre className="whitespace-pre-wrap font-sans">{item.description_extra}</pre>}
-              </div>
-            </div>
+              <p className="mt-5 text-sm leading-7 text-[#CFD3D2]">{item.description}</p>
+              {item.description_extra && (
+                <>
+                  <div className="mt-6 h-px w-20 bg-[#6FA3C2]/45" />
+                  <p className="mt-5 text-sm leading-7 text-[#CFD3D2]/88">{item.description_extra}</p>
+                </>
+              )}
+              {item.technologies && item.technologies.length > 0 && (
+                <div className="mt-6 flex flex-wrap gap-2">
+                  {item.technologies.map((tech) => (
+                    <span key={tech} className="rounded-full border border-[#6FA3C2]/30 px-3 py-1 text-xs text-[#CFD3D2]/80">
+                      {tech}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </article>
           ))}
         </div>
       </section>
 
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[var(--muted)]">
-          Software Engineering
-        </p>
-        <div className="mt-6 space-y-6">
-          {softwareEngineering.map((item, index) => (
-            <div key={index} className="rounded-2xl bg-[var(--paper)] p-5">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div>
-                  <h3 className="font	font-display text-2xl text-[var(--ink)]">{item.position}</h3>
-                  <p className="text-sm text-[var(--muted)]">{item.company} • {item.location}</p>
+      {/* Software Engineering */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Software Engineering</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">A decade of systems thinking.</h2>
+        </div>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-6">
+            {softwareEngineering.filter((_, i) => i % 2 === 0).map((item, index) => (
+              <article
+                key={index}
+                className={`rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm ${index > 0 ? 'md:ml-10' : ''}`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.company} · {item.location}</div>
+                    <h3 className="mt-2 font-display text-2xl tracking-[-0.03em]">{item.position}</h3>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.time}</span>
                 </div>
-                <span className="text-xs uppercase tracking-[0.25em] text-[var(--muted)]">{item.time}</span>
-              </div>
-              <div className="mt-4 space-y-3 text-sm leading-relaxed text-[var(--ink)]">
-                <pre className="whitespace-pre-wrap font-sans">{item.description}</pre>
-                {item.description_extra && <pre className="whitespace-pre-wrap font-sans">{item.description_extra}</pre>}
-              </div>
-            </div>
-          ))}
+                <p className="mt-5 text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+                {item.description_extra && (
+                  <p className="mt-3 text-sm leading-7 text-[#063C6B]/60">{item.description_extra}</p>
+                )}
+                {item.technologies && item.technologies.length > 0 && (
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {item.technologies.map((tech) => (
+                      <span key={tech} className="rounded-full border border-[#063C6B]/10 px-3 py-1 text-xs text-[#063C6B]/70">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+          <div className="space-y-6 md:pt-14">
+            {softwareEngineering.filter((_, i) => i % 2 === 1).map((item, index) => (
+              <article
+                key={index}
+                className="rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div>
+                    <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.company} · {item.location}</div>
+                    <h3 className="mt-2 font-display text-2xl tracking-[-0.03em]">{item.position}</h3>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.time}</span>
+                </div>
+                <p className="mt-5 text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+                {item.description_extra && (
+                  <p className="mt-3 text-sm leading-7 text-[#063C6B]/60">{item.description_extra}</p>
+                )}
+                {item.technologies && item.technologies.length > 0 && (
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {item.technologies.map((tech) => (
+                      <span key={tech} className="rounded-full border border-[#063C6B]/10 px-3 py-1 text-xs text-[#063C6B]/70">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
         </div>
       </section>
     </div>
@@ -59,6 +122,3 @@ function ExperiencePage({ leadership, softwareEngineering }: ExperiencePageProps
 }
 
 export default ExperiencePage;
-
-
-

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
-import developer from '../../src/data/developer';
-import resume from '../../src/data/resume';
+import developer from '../data/developer';
+import resume from '../data/resume';
 
 function Home() {
   return (
@@ -17,7 +17,7 @@ function Home() {
             {resume.headline.split(',')[0]}
           </h1>
           <p className="mt-8 max-w-2xl text-base leading-8 text-[#063C6B]/72 md:text-lg">
-            {resume.summary}
+            {developer.profile.tagline}
           </p>
           <div className="mt-10 flex flex-wrap gap-4">
             <Link

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,101 +1,129 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import developer from '../../src/data/developer';
 import resume from '../../src/data/resume';
 
-interface HomeProps {
-  contactItems: { label: string; value: string; href: string }[];
-}
-
-function Home({ contactItems }: HomeProps) {
+function Home() {
   return (
-    <div className="space-y-10 animate-fade-up">
-      <header className="grid items-end gap-10 lg:grid-cols-[1.1fr_0.9fr]">
-        <div className="space-y-6" style={{ animationDelay: '0.05s' }}>
-          <p className="text-xs uppercase tracking-[0.35em] text-[var(--muted)]">
-            {developer.profile.tagline}
-          </p>
-          <h1 className="font-display text-5xl text-[var(--ink)] sm:text-6xl lg:text-7xl">
-            {developer.profile.name}
+    <div className="animate-fade-up">
+      {/* Hero */}
+      <section className="relative grid min-h-[78vh] items-center gap-16 py-14 md:grid-cols-[1.1fr_0.9fr] md:py-20">
+        <div className="relative z-10 max-w-3xl">
+          <div className="mb-6 text-xs uppercase tracking-[0.28em] text-[#063C6B]/45">
+            software · systems · operations · automation
+          </div>
+          <h1 className="font-display text-5xl leading-[0.94] tracking-[-0.045em] md:text-7xl lg:text-[5.6rem]">
+            {resume.headline.split(',')[0]}
           </h1>
-          <p className="text-lg text-[var(--muted)] sm:text-xl">
-            {resume.headline}
+          <p className="mt-8 max-w-2xl text-base leading-8 text-[#063C6B]/72 md:text-lg">
+            {resume.summary}
           </p>
-          <div className="flex flex-wrap gap-2 screen-only">
-            {resume.focusAreas.map((item: string) => (
-              <span
-                key={item}
-                className="rounded-full border border-[var(--border)] bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ink)]"
-              >
-                {item}
-              </span>
-            ))}
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link
+              to="/experience"
+              className="inline-flex items-center rounded-full border border-[#063C6B]/18 bg-white/60 px-6 py-3 text-sm text-[#063C6B] backdrop-blur-sm transition hover:border-[#F07A20]/50 hover:text-[#F07A20]"
+            >
+              View experience
+            </Link>
+            <Link
+              to="/contact"
+              className="inline-flex items-center rounded-full border border-[#063C6B] bg-[#063C6B] px-6 py-3 text-sm text-[#F2F1F0] transition hover:bg-[#0C4A80]"
+            >
+              Get in touch
+            </Link>
           </div>
-          <p className="print-only mt-2 text-sm text-[var(--muted)]">
-            {resume.focusAreas.join(' • ')}
-          </p>
         </div>
 
-        <div className="rounded-3xl border border-[var(--border)] bg-white/80 p-6 shadow-[var(--shadow)] backdrop-blur animate-fade-up" style={{ animationDelay: '0.15s' }}>
-          <div className="mb-4 flex items-center justify-between">
-            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--muted)]">
-              Contact
-            </p>
-            <span className="text-xs text-[var(--muted)]">Open to collaborations</span>
-          </div>
-          <div className="space-y-3 text-sm text-[var(--ink)]">
-            {contactItems.map((item) => (
-              <div key={item.label} className="flex items-center justify-between gap-4">
-                <span className="text-xs uppercase tracking-[0.2em] text-[var(--muted)]">
-                  {item.label}
-                </span>
-                <a
-                  className="font-medium text-[var(--ink)] transition hover:text-[var(--accent)]"
-                  href={item.href}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {item.value}
-                </a>
+        {/* Decorative SVG art card */}
+        <div className="relative mx-auto w-full max-w-[30rem]">
+          <div className="absolute -left-10 top-10 h-[24rem] w-[24rem] rounded-[48%] border border-[#063C6B]/10 bg-[#6FA3C2]/10" />
+          <div className="relative overflow-hidden rounded-[2.5rem] border border-[#063C6B]/10 bg-white/60 shadow-[0_24px_80px_rgba(6,60,107,0.08)] backdrop-blur-sm">
+            <div className="aspect-[4/5] w-full bg-[linear-gradient(180deg,rgba(255,255,255,0.75),rgba(255,255,255,0.45))]">
+              <svg className="h-full w-full" viewBox="0 0 520 650" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M-40 405C58 375 104 328 175 328C238 328 271 365 320 365C377 365 409 322 468 322C527 322 578 373 635 392" stroke="#063C6B" strokeWidth="2" />
+                <path d="M-30 442C76 413 123 382 195 382C264 382 302 427 356 427C416 427 448 385 504 385C560 385 602 420 655 445" stroke="#6FA3C2" strokeWidth="2" />
+                <path d="M250 132C284 122 315 133 340 164C364 194 364 226 344 259C325 289 296 307 258 312" stroke="#063C6B" strokeWidth="2" />
+                <path d="M205 312C220 281 251 257 289 250C336 242 381 258 415 301C449 344 453 392 427 443" stroke="#063C6B" strokeWidth="2" />
+                <path d="M85 459C127 422 168 404 208 404C257 404 304 430 347 482" stroke="#063C6B" strokeWidth="1.5" />
+                <path d="M300 130C344 86 404 77 453 111C503 146 515 205 487 266" stroke="#6FA3C2" strokeWidth="1.5" />
+                <circle cx="392" cy="142" r="32" fill="#F2F1F0" stroke="#063C6B" strokeWidth="1.2" />
+              </svg>
+              <div className="absolute left-6 top-6 text-[11px] uppercase tracking-[0.28em] text-[#063C6B]/45">Systems in motion</div>
+              <div className="absolute bottom-6 left-6 max-w-[15rem] text-sm leading-6 text-[#063C6B]/58">
+                {developer.profile.name} · {new Date().getFullYear()}
               </div>
-            ))}
+            </div>
           </div>
-          <div className="mt-5 rounded-2xl bg-[var(--paper)] px-4 py-3 text-xs uppercase tracking-[0.25em] text-[var(--muted)]">
-            {developer.profile.tagline}
-          </div>
-        </div>
-      </header>
-
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur animate-fade-up" style={{ animationDelay: '0.2s' }}>
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
-          Profile
-        </p>
-        <div className="mt-4 text-lg leading-relaxed text-[var(--ink)]">
-          <ReactMarkdown>{resume.summary}</ReactMarkdown>
         </div>
       </section>
 
-      <section className="rounded-3xl border border-[
-    var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur animate-fade-up" style={{ animationDelay: '0.4s' }}>
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
-          Ventures & Community
-        </p>
-        <p className="mt-3 text-sm text-[var(--muted)]">{resume.ventures.header}</p>
-        <div className="mt-6 grid gap-4 sm:grid-cols-2">
-          {resume.ventures.items.map((item: { name: string; url: string; description: string }) => (
-            <a
-              key={item.name}
-              href={item.url}
-              target="_blank"
-              rel="noreferrer"
-              className="group rounded-2xl border border-transparent bg-[var(--paper)] p-4 transition hover:-translate-y-1 hover:border-[var(--accent)] hover:shadow-[var(--shadow)]"
-            >
-              <h3 className="font-display text-xl text-[var(--ink)] group-hover:text-[var(--accent)]">
-                {item.name}
-              </h3>
-              <p className="mt-2 text-sm text-[var(--muted)]">{item.description}</p>
-            </a>
-          ))}
+      {/* Profile summary */}
+      <section className="relative mt-4 grid gap-10 md:grid-cols-[0.95fr_1.05fr] md:gap-14">
+        <div className="relative border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Profile</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">
+            Built at the intersection of craft and systems.
+          </h2>
+        </div>
+        <div className="relative border-t border-[#063C6B]/12 pt-8 text-[#063C6B]/72">
+          <div className="max-w-2xl text-base leading-8">
+            <ReactMarkdown>{resume.summary}</ReactMarkdown>
+          </div>
+          <div className="mt-8 grid gap-3 sm:grid-cols-2">
+            {resume.focusAreas.map((item: string) => (
+              <div key={item} className="rounded-2xl border border-[#063C6B]/10 bg-white/55 px-4 py-4 text-sm backdrop-blur-sm">
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Ventures */}
+      <section className="mt-24">
+        <div className="flex items-end justify-between gap-8 border-b border-[#063C6B]/10 pb-4">
+          <div>
+            <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Ventures & Community</div>
+            <h2 className="mt-3 font-display text-3xl tracking-[-0.04em] md:text-5xl">Projects arranged in flow.</h2>
+          </div>
+          <div className="hidden text-sm text-[#063C6B]/42 md:block">community · craft · culture</div>
+        </div>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-6">
+            {resume.ventures.items.slice(0, 2).map((item, idx) => (
+              <a
+                key={item.name}
+                href={item.url}
+                target="_blank"
+                rel="noreferrer"
+                className={`block rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm transition hover:-translate-y-1 hover:border-[#F07A20]/30 ${idx === 1 ? 'md:ml-10' : ''}`}
+              >
+                <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42">{item.description.split(' ').slice(0, 3).join(' ')}</div>
+                <h3 className="mt-3 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.name}</h3>
+                <p className="mt-4 max-w-2xl text-sm leading-7 text-[#063C6B]/72">{item.description}</p>
+              </a>
+            ))}
+          </div>
+          <div className="md:pt-14">
+            {resume.ventures.items.slice(2).map((item, idx) => (
+              <a
+                key={item.name}
+                href={item.url}
+                target="_blank"
+                rel="noreferrer"
+                className={`block rounded-[2rem] border border-[#063C6B]/10 p-7 shadow-[0_18px_56px_rgba(6,60,107,0.12)] transition hover:-translate-y-1 ${idx === 0 ? 'bg-[#063C6B] text-[#F2F1F0]' : 'bg-white/60 backdrop-blur-sm mt-6'}`}
+              >
+                <div className={`text-xs uppercase tracking-[0.22em] ${idx === 0 ? 'text-[#CFD3D2]/70' : 'text-[#063C6B]/42'}`}>
+                  {item.description.split(' ').slice(0, 3).join(' ')}
+                </div>
+                <h3 className="mt-3 font-display text-2xl tracking-[-0.03em] md:text-3xl">{item.name}</h3>
+                <p className={`mt-4 text-sm leading-7 ${idx === 0 ? 'text-[#CFD3D2]' : 'text-[#063C6B]/72'}`}>{item.description}</p>
+                {idx === 0 && <div className="mt-8 h-px w-20 bg-[#6FA3C2]/45" />}
+              </a>
+            ))}
+          </div>
         </div>
       </section>
     </div>
@@ -103,14 +131,3 @@ function Home({ contactItems }: HomeProps) {
 }
 
 export default Home;
-
-
-
-
-
-
-
-
-
-
-

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,14 +8,31 @@ interface LayoutProps {
 
 function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_#f5efe6_0%,_#ede2d5_40%,_#e2d6c7_100%)] text-[var(--ink)]">
+    <div className="min-h-screen bg-[#F2F1F0] text-[#063C6B] selection:bg-[#F07A20] selection:text-white">
       <div className="relative overflow-hidden">
-        <div className="pointer-events-none absolute -top-20 -right-24 h-80 w-80 rounded-full bg-[radial-gradient(circle,_rgba(199,118,58,0.25),_transparent_70%)] blur-2xl animate-float" />
-        <div className="pointer-events-none absolute bottom-0 left-[-120px] h-72 w-72 rounded-full bg-[radial-gradient(circle,_rgba(47,111,109,0.25),_transparent_70%)] blur-2xl animate-float" />
-        
+        {/* Paper texture */}
+        <div className="pointer-events-none absolute inset-0 opacity-[0.05] mix-blend-multiply [background-image:radial-gradient(rgba(6,60,107,0.65)_0.7px,transparent_0.7px)] [background-size:12px_12px]" />
+
+        {/* Wave lines */}
+        <svg
+          className="pointer-events-none absolute left-0 top-0 h-[520px] w-full opacity-[0.14]"
+          viewBox="0 0 1440 520"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="none"
+        >
+          <path d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176" stroke="#063C6B" strokeWidth="1.5" />
+          <path d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285" stroke="#6FA3C2" strokeWidth="1.2" />
+          <path d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339" stroke="#063C6B" strokeWidth="1" />
+        </svg>
+
+        {/* Crest orbs */}
+        <div className="pointer-events-none absolute right-[-8rem] top-24 h-[32rem] w-[32rem] rounded-[42%] border border-[#063C6B]/12 bg-[#6FA3C2]/14 blur-[1px]" />
+        <div className="pointer-events-none absolute right-[2rem] top-16 h-[22rem] w-[22rem] rounded-[45%] border border-[#063C6B]/10 bg-white/30" />
+
         <Navigation />
 
-        <main className="relative mx-auto max-w-6xl px-6 py-12 lg:py-16">
+        <main className="relative mx-auto max-w-6xl px-6 py-8 md:px-10 md:py-10">
           {children}
         </main>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,20 +3,24 @@ import { Link } from 'react-router-dom';
 
 function Navigation() {
   return (
-    <nav className="sticky top-0 z-50 border-b border-[var(--border)] bg-white/70 backdrop-blur px-6 py-4">
-      <div className="mx-auto flex max-w-6xl items-center justify-between">
-        <Link to="/" className="font-display text-lg font-bold text-[var(--ink)]">
-          JS
+    <nav className="relative z-50 px-6 md:px-10">
+      <div className="mx-auto flex max-w-6xl items-center justify-between border-b border-[#063C6B]/10 pb-5 pt-8">
+        <Link to="/" className="group">
+          <div className="font-medium text-sm tracking-[0.24em] uppercase text-[#063C6B]/85">JMSALCIDO</div>
+          <div className="mt-1 text-xs tracking-[0.16em] uppercase text-[#063C6B]/45">software · systems · operations</div>
         </Link>
-        <ul className="flex gap-8 text-xs uppercase tracking-[0.2em] text-[var(--muted)] sm:text-sm">
+        <ul className="hidden md:flex gap-8 text-sm text-[#063C6B]/68">
           <li>
-            <Link to="/" className="transition hover:text-[var(--accent)]">Home</Link>
+            <Link to="/" className="transition hover:text-[#F07A20]">Home</Link>
           </li>
           <li>
-            <Link to="/experience" className="transition hover:text-[var(--accent)]">Experience</Link>
+            <Link to="/experience" className="transition hover:text-[#F07A20]">Experience</Link>
           </li>
           <li>
-            <Link to="/skills" className="transition hover:text-[var(--accent)]">Skills</Link>
+            <Link to="/skills" className="transition hover:text-[#F07A20]">Skills</Link>
+          </li>
+          <li>
+            <Link to="/contact" className="transition hover:text-[#F07A20]">Contact</Link>
           </li>
         </ul>
       </div>

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -10,53 +10,63 @@ interface SkillsPageProps {
 
 function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPageProps) {
   return (
-    <div className="space-y-10 animate-fade-up">
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
-          Signature Strengths
-        </p>
-        <ul className="mt-5 space-y-4 text-sm text-[var(--ink)]">
+    <div className="animate-fade-up space-y-24 pb-10">
+      {/* Highlights */}
+      <section>
+        <div className="border-t border-[#063C6B]/12 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Signature Strengths</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">Discipline below the surface.</h2>
+        </div>
+        <div className="mt-10 grid gap-6 md:grid-cols-2">
           {highlights?.map((highlight, index) => (
-            <li key={index} className="rounded-2xl bg-[var(--paper)] p-4 leading-relaxed">
-              {highlight}
-            </li>
-          )) || (
-            <li className="rounded-2xl bg-[var(--paper)] p-4 leading-relaxed">
-              Placeholder for strength item
-            </li>
-          )}
-        </ul>
-      </section>
-
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
-          Skills Blend
-        </p>
-        <div className="mt-5 flex flex-wrap gap-2">
-          {skillItems.map((skill) => (
-            <div
-              key={skill.name}
-              className="rounded-full border border-[var(--border)] bg-[var(--paper)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ink)]"
+            <article
+              key={index}
+              className={`rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm ${index === 1 ? 'md:mt-10' : ''}`}
             >
-              {skill.name}
-            </div>
+              <p className="text-sm leading-7 text-[#063C6B]/72">{highlight}</p>
+            </article>
           ))}
         </div>
       </section>
 
-      <section className="rounded-3xl border border-[var(--border)] bg-white/85 p-7 shadow-[var(--shadow)] backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[var(--muted)]">
-          Languages & Interests
-        </p>
-        <div className="mt-5 space-y-6 text-sm text-[var(--ink)]">
+      {/* Skills */}
+      <section className="grid gap-10 md:grid-cols-[0.86fr_1.14fr]">
+        <div className="border-t border-[#063C6B]/10 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Skills Blend</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-5xl">The stack beneath the work.</h2>
+          <p className="mt-5 max-w-md text-base leading-8 text-[#063C6B]/72">
+            Tools and disciplines used across business, product, and engineering contexts.
+          </p>
+        </div>
+        <div className="rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm">
+          <div className="grid grid-cols-2 gap-3">
+            {skillItems.map((skill) => (
+              <div
+                key={skill.name}
+                className="rounded-2xl border border-[#063C6B]/10 px-4 py-4 text-center text-sm text-[#063C6B]/80"
+              >
+                {skill.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Languages & Interests */}
+      <section className="grid gap-10 md:grid-cols-[0.95fr_1.05fr]">
+        <div className="border-t border-[#063C6B]/10 pt-8">
+          <div className="text-xs uppercase tracking-[0.26em] text-[#063C6B]/42">Languages & Interests</div>
+          <h2 className="mt-4 font-display text-3xl tracking-[-0.04em] md:text-4xl">Beyond the screen.</h2>
+        </div>
+        <div className="border-t border-[#063C6B]/10 pt-8 space-y-8">
           {languages && languages.length > 0 && (
             <div>
-              <h4 className="text-xs font-bold uppercase tracking-wider mb-3 text-[var(--muted)]">Languages</h4>
-              <ul className="space-y-2">
+              <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42 mb-4">Languages</div>
+              <ul className="space-y-3">
                 {languages.map((lang, index) => (
-                  <li key={index} className="flex justify-between items-center border-b border-[var(--border)] pb-1">
+                  <li key={index} className="flex justify-between items-center border-b border-[#063C6B]/10 pb-3 text-sm text-[#063C6B]/80">
                     <span>{lang.name}</span>
-                    <span className="text-[var(--muted)] text-xs">{lang.level}</span>
+                    <span className="text-xs uppercase tracking-[0.18em] text-[#063C6B]/42">{lang.level}</span>
                   </li>
                 ))}
               </ul>
@@ -64,12 +74,12 @@ function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPage
           )}
           {interests && interests.length > 0 && (
             <div>
-              <h4 className="text-xs font-bold uppercase tracking-wider mb-3 text-[var(--muted)]">Interests</h4>
-              <div className="flex flex-wrap gap-2">
+              <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42 mb-4">Interests</div>
+              <div className="grid grid-cols-2 gap-3">
                 {interests.map((interest, index) => (
-                  <span key={index} className="rounded-full bg-[var(--paper)] px-3 py-1 text-xs border border-[var(--border)]">
+                  <div key={index} className="rounded-2xl border border-[#063C6B]/10 px-4 py-3 text-sm text-[#063C6B]/80">
                     {interest}
-                  </span>
+                  </div>
                 ))}
               </div>
             </div>
@@ -81,8 +91,3 @@ function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPage
 }
 
 export default SkillsPage;
-
-
-
-
-

--- a/src/components/SkillsPage.tsx
+++ b/src/components/SkillsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skill } from '../../src/data/resume';
+import { Skill } from '../data/resume';
 
 interface SkillsPageProps {
   skillItems: Skill[];
@@ -20,7 +20,7 @@ function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPage
         <div className="mt-10 grid gap-6 md:grid-cols-2">
           {highlights?.map((highlight, index) => (
             <article
-              key={index}
+              key={highlight}
               className={`rounded-[2rem] border border-[#063C6B]/10 bg-white/60 p-7 shadow-[0_12px_40px_rgba(6,60,107,0.05)] backdrop-blur-sm ${index === 1 ? 'md:mt-10' : ''}`}
             >
               <p className="text-sm leading-7 text-[#063C6B]/72">{highlight}</p>
@@ -76,8 +76,8 @@ function SkillsPage({ skillItems, highlights, languages, interests }: SkillsPage
             <div>
               <div className="text-xs uppercase tracking-[0.22em] text-[#063C6B]/42 mb-4">Interests</div>
               <div className="grid grid-cols-2 gap-3">
-                {interests.map((interest, index) => (
-                  <div key={index} className="rounded-2xl border border-[#063C6B]/10 px-4 py-3 text-sm text-[#063C6B]/80">
+                {interests.map((interest) => (
+                  <div key={interest} className="rounded-2xl border border-[#063C6B]/10 px-4 py-3 text-sm text-[#063C6B]/80">
                     {interest}
                   </div>
                 ))}

--- a/src/index.css
+++ b/src/index.css
@@ -3,17 +3,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
-  --ink: #1e1713;
-  --muted: #5f554d;
-  --accent: #c7763a;
-  --accent-2: #2f6f6d;
-  --paper: #f7f1e8;
-  --border: rgba(30, 23, 19, 0.12);
-  --shadow: 0 16px 40px rgba(30, 23, 19, 0.12);
+  --bg: #F2F1F0;
+  --ink: #063C6B;
+  --muted: rgba(6, 60, 107, 0.60);
+  --accent: #F07A20;
+  --accent-2: #6FA3C2;
+  --border: rgba(6, 60, 107, 0.10);
+  --shadow: 0 12px 40px rgba(6, 60, 107, 0.05);
 }
 
 body {
   font-family: 'Space Grotesk', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background-color: #F2F1F0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -33,33 +34,17 @@ body {
   }
 }
 
-@keyframes floatSlow {
-  from {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
 .animate-fade-up {
   animation: fadeUp 0.9s ease both;
 }
 
-.animate-float {
-  animation: floatSlow 9s ease-in-out infinite;
-}
-
 @media print {
   :root {
+    --bg: #ffffff;
     --ink: #111111;
     --muted: #333333;
     --accent: #000000;
     --accent-2: #000000;
-    --paper: #ffffff;
     --border: rgba(0, 0, 0, 0.18);
     --shadow: none;
   }
@@ -109,13 +94,8 @@ body {
     text-decoration: none !important;
   }
 
-  .animate-fade-up,
-  .animate-float {
+  .animate-fade-up {
     animation: none !important;
-  }
-
-  .bg-\[radial-gradient\(circle_at_top,_\#f5efe6_0%,_\#ede2d5_40%,_\#e2d6c7_100%\)\] {
-    background: #ffffff !important;
   }
 
   .backdrop-blur {
@@ -146,17 +126,6 @@ body {
 
   [class*="border"] {
     border: none !important;
-  }
-
-  .uppercase {
-    text-transform: none !important;
-  }
-
-  .tracking-\[0\.35em\],
-  .tracking-\[0\.3em\],
-  .tracking-\[0\.25em\],
-  .tracking-\[0\.2em\] {
-    letter-spacing: 0.04em !important;
   }
 
   .screen-only {


### PR DESCRIPTION
## Summary

- Replace warm earthy palette with Ukiyo-e navy/ocean design system (#063C6B, #F07A20, #6FA3C2, #F2F1F0)
- Rebuild Layout shell with SVG wave lines, crest orbs, and paper dot texture visible on every page
- Rebuild Navigation with JMSALCIDO brand block, transparent style, and new Contact link
- Rebuild Home with asymmetric hero grid, decorative SVG art card, frosted glass venture cards
- Restyle Experience and Skills pages with frosted glass cards, dark navy featured cards, bordered pill grids
- Add new `/contact` route with email, LinkedIn, and GitHub rounded-full links

## Test Plan

- [ ] Visit `/` — hero grid, SVG art card, profile summary, ventures in asymmetric grid
- [ ] Visit `/experience` — dark navy CEO card, frosted glass job cards, tech pills
- [ ] Visit `/skills` — highlights grid, bordered skill pills, languages and interests
- [ ] Visit `/contact` — headline, three rounded-full contact links with orange hover
- [ ] Verify nav: all 4 links (Home, Experience, Skills, Contact) route correctly
- [ ] Verify wave lines, crest orbs, and paper texture visible on all pages
- [ ] Verify build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)