### PR TITLE
feat: animate background waves with stroke-crawl effect

### DIFF
--- a/docs/superpowers/plans/2026-04-19-wave-animation.md
+++ b/docs/superpowers/plans/2026-04-19-wave-animation.md
@@ -1,0 +1,116 @@
+# Wave Stroke-Crawl Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Animate the three decorative SVG wave paths in the layout background so they appear to have water flowing continuously along them.
+
+**Architecture:** Each wave path gets a `strokeDasharray` repeating pattern and an `animation` style that cycles `strokeDashoffset` by exactly one pattern period, creating a seamless infinite crawl. Three separate `@keyframes` rules (one per period value) are added to `index.css`; the animation is applied via `style` prop inline on each `<path>`.
+
+**Tech Stack:** React, Tailwind CSS (v4), plain CSS `@keyframes`
+
+---
+
+### Task 1: Add keyframes to index.css
+
+**Files:**
+- Modify: `src/index.css`
+
+- [ ] **Step 1: Add three `@keyframes` blocks after the existing `floatSlow` keyframe (line 46)**
+
+Open `src/index.css` and insert after the closing `}` of `floatSlow`:
+
+```css
+@keyframes waveCrawl25 {
+  to { stroke-dashoffset: -25; }
+}
+
+@keyframes waveCrawl20 {
+  to { stroke-dashoffset: -20; }
+}
+
+@keyframes waveCrawl18 {
+  to { stroke-dashoffset: -18; }
+}
+```
+
+- [ ] **Step 2: Verify the file parses without errors**
+
+Run: `npx tsc --noEmit`
+Expected: no errors (CSS isn't checked by tsc, but confirms the project still builds)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.css
+git commit -m "feat: add wave stroke-crawl keyframes"
+```
+
+---
+
+### Task 2: Apply animation to the three SVG wave paths in Layout.tsx
+
+**Files:**
+- Modify: `src/components/Layout.tsx`
+
+- [ ] **Step 1: Update the top wave path (dark blue, strokeWidth 1.5)**
+
+Find the first `<path>` inside the wave SVG (line ~24) and add `strokeDasharray` and `style`:
+
+```tsx
+<path
+  d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176"
+  stroke="#063C6B"
+  strokeWidth="1.5"
+  strokeDasharray="18 7"
+  style={{ animation: 'waveCrawl25 8s linear infinite' }}
+/>
+```
+
+- [ ] **Step 2: Update the mid wave path (light blue, strokeWidth 1.2)**
+
+Find the second `<path>` (line ~25) and update it:
+
+```tsx
+<path
+  d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285"
+  stroke="#6FA3C2"
+  strokeWidth="1.2"
+  strokeDasharray="14 6"
+  style={{ animation: 'waveCrawl20 13s linear infinite' }}
+/>
+```
+
+- [ ] **Step 3: Update the bottom wave path (dark blue, strokeWidth 1)**
+
+Find the third `<path>` (line ~26) and update it:
+
+```tsx
+<path
+  d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339"
+  stroke="#063C6B"
+  strokeWidth="1"
+  strokeDasharray="10 8"
+  style={{ animation: 'waveCrawl18 10s linear infinite' }}
+/>
+```
+
+- [ ] **Step 4: Start the dev server and visually verify**
+
+Run: `npm run dev`
+
+Open `http://localhost:5173` in a browser and confirm:
+- All three wave lines are animated and crawling
+- Each wave moves at a visibly different speed (top: fast, bottom: medium, mid: slowest)
+- Animation loops without any jump or glitch
+- Page content (nav, main, footer) is unaffected
+
+- [ ] **Step 5: Verify print styles suppress animation**
+
+In browser DevTools, open the Rendering panel → set "Emulate CSS media type" to `print`. Confirm the waves become static (no movement).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Layout.tsx
+git commit -m "feat: animate SVG wave paths with stroke-crawl effect"
+```

--- a/docs/superpowers/specs/2026-04-19-wave-animation-design.md
+++ b/docs/superpowers/specs/2026-04-19-wave-animation-design.md
@@ -1,0 +1,50 @@
+# Wave Background Animation Design
+
+**Date:** 2026-04-19  
+**Status:** Approved
+
+## Goal
+
+Add a flowing "stroke-crawl" animation to the three decorative SVG wave paths in `src/components/Layout.tsx`. The waves should appear to have water running along them continuously.
+
+## How It Works
+
+Each wave path gets a repeating `stroke-dasharray` pattern. Animating `stroke-dashoffset` from `0` to `-(dasharray period)` makes the dashes flow forward along the wave's contour seamlessly and infinitely.
+
+## Implementation
+
+### CSS (`src/index.css`)
+
+Add three `@keyframes` rules — one per wave — since each has a different dasharray period (to avoid the offset value needing to be computed at runtime):
+
+```css
+@keyframes waveCrawl25 {
+  to { stroke-dashoffset: -25; }
+}
+@keyframes waveCrawl20 {
+  to { stroke-dashoffset: -20; }
+}
+@keyframes waveCrawl18 {
+  to { stroke-dashoffset: -18; }
+}
+```
+
+### SVG paths (`src/components/Layout.tsx`)
+
+| Wave | `stroke-dasharray` | Period | Keyframe | Duration | Easing |
+|------|--------------------|--------|----------|----------|--------|
+| Top (`#063C6B`, strokeWidth 1.5) | `"18 7"` | 25px | `waveCrawl25` | 8s | linear, infinite |
+| Mid (`#6FA3C2`, strokeWidth 1.2) | `"14 6"` | 20px | `waveCrawl20` | 13s | linear, infinite |
+| Bottom (`#063C6B`, strokeWidth 1) | `"10 8"` | 18px | `waveCrawl18` | 10s | linear, infinite |
+
+Applied via `style` prop on each `<path>` (inline style is cleaner than three separate Tailwind keyframe classes for per-element values).
+
+## Print Safety
+
+The existing `animation: none !important` rule in the `@media print` block in `index.css` already covers these animations. No extra work needed.
+
+## Out of Scope
+
+- No JS, no requestAnimationFrame, no library dependency
+- No change to wave shape, color, or opacity
+- No interaction (hover speed-up, etc.)

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,14 +8,31 @@ interface LayoutProps {
 
 function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_#f5efe6_0%,_#ede2d5_40%,_#e2d6c7_100%)] text-[var(--ink)]">
+    <div className="min-h-screen bg-[#F2F1F0] text-[#063C6B] selection:bg-[#F07A20] selection:text-white">
       <div className="relative overflow-hidden">
-        <div className="pointer-events-none absolute -top-20 -right-24 h-80 w-80 rounded-full bg-[radial-gradient(circle,_rgba(199,118,58,0.25),_transparent_70%)] blur-2xl animate-float" />
-        <div className="pointer-events-none absolute bottom-0 left-[-120px] h-72 w-72 rounded-full bg-[radial-gradient(circle,_rgba(47,111,109,0.25),_transparent_70%)] blur-2xl animate-float" />
-        
+        {/* Paper texture */}
+        <div className="pointer-events-none absolute inset-0 opacity-[0.05] mix-blend-multiply [background-image:radial-gradient(rgba(6,60,107,0.65)_0.7px,transparent_0.7px)] [background-size:12px_12px]" />
+
+        {/* Wave lines */}
+        <svg
+          className="pointer-events-none absolute left-0 top-0 h-[520px] w-full opacity-[0.14]"
+          viewBox="0 0 1440 520"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="none"
+        >
+          <path d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176" stroke="#063C6B" strokeWidth="1.5" />
+          <path d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285" stroke="#6FA3C2" strokeWidth="1.2" />
+          <path d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339" stroke="#063C6B" strokeWidth="1" />
+        </svg>
+
+        {/* Crest orbs */}
+        <div className="pointer-events-none absolute right-[-8rem] top-24 h-[32rem] w-[32rem] rounded-[42%] border border-[#063C6B]/12 bg-[#6FA3C2]/14 blur-[1px]" />
+        <div className="pointer-events-none absolute right-[2rem] top-16 h-[22rem] w-[22rem] rounded-[45%] border border-[#063C6B]/10 bg-white/30" />
+
         <Navigation />
 
-        <main className="relative mx-auto max-w-6xl px-6 py-12 lg:py-16">
+        <main className="relative mx-auto max-w-6xl px-6 py-8 md:px-10 md:py-10">
           {children}
         </main>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -21,9 +21,27 @@ function Layout({ children }: LayoutProps) {
           xmlns="http://www.w3.org/2000/svg"
           preserveAspectRatio="none"
         >
-          <path d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176" stroke="#063C6B" strokeWidth="1.5" />
-          <path d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285" stroke="#6FA3C2" strokeWidth="1.2" />
-          <path d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339" stroke="#063C6B" strokeWidth="1" />
+          <path
+            d="M0 196C119 168 166 121 279 121C409 121 468 240 607 240C732 240 806 149 932 149C1060 149 1111 247 1228 247C1325 247 1373 204 1440 176"
+            stroke="#063C6B"
+            strokeWidth="1.5"
+            strokeDasharray="18 7"
+            style={{ animation: 'waveCrawl25 8s linear infinite' }}
+          />
+          <path
+            d="M0 266C97 266 161 212 273 212C415 212 460 332 607 332C739 332 794 251 929 251C1078 251 1131 356 1243 356C1324 356 1380 317 1440 285"
+            stroke="#6FA3C2"
+            strokeWidth="1.2"
+            strokeDasharray="14 6"
+            style={{ animation: 'waveCrawl20 13s linear infinite' }}
+          />
+          <path
+            d="M0 352C137 319 188 286 301 286C426 286 493 395 615 395C751 395 812 317 942 317C1068 317 1113 407 1229 407C1324 407 1377 372 1440 339"
+            stroke="#063C6B"
+            strokeWidth="1"
+            strokeDasharray="10 8"
+            style={{ animation: 'waveCrawl18 10s linear infinite' }}
+          />
         </svg>
 
         {/* Crest orbs */}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,20 +3,24 @@ import { Link } from 'react-router-dom';
 
 function Navigation() {
   return (
-    <nav className="sticky top-0 z-50 border-b border-[var(--border)] bg-white/70 backdrop-blur px-6 py-4">
-      <div className="mx-auto flex max-w-6xl items-center justify-between">
-        <Link to="/" className="font-display text-lg font-bold text-[var(--ink)]">
-          JS
+    <nav className="relative z-50 px-6 md:px-10">
+      <div className="mx-auto flex max-w-6xl items-center justify-between border-b border-[#063C6B]/10 pb-5 pt-8">
+        <Link to="/" className="group">
+          <div className="font-medium text-sm tracking-[0.24em] uppercase text-[#063C6B]/85">JMSALCIDO</div>
+          <div className="mt-1 text-xs tracking-[0.16em] uppercase text-[#063C6B]/45">software · systems · operations</div>
         </Link>
-        <ul className="flex gap-8 text-xs uppercase tracking-[0.2em] text-[var(--muted)] sm:text-sm">
+        <ul className="hidden md:flex gap-8 text-sm text-[#063C6B]/68">
           <li>
-            <Link to="/" className="transition hover:text-[var(--accent)]">Home</Link>
+            <Link to="/" className="transition hover:text-[#F07A20]">Home</Link>
           </li>
           <li>
-            <Link to="/experience" className="transition hover:text-[var(--accent)]">Experience</Link>
+            <Link to="/experience" className="transition hover:text-[#F07A20]">Experience</Link>
           </li>
           <li>
-            <Link to="/skills" className="transition hover:text-[var(--accent)]">Skills</Link>
+            <Link to="/skills" className="transition hover:text-[#F07A20]">Skills</Link>
+          </li>
+          <li>
+            <Link to="/contact" className="transition hover:text-[#F07A20]">Contact</Link>
           </li>
         </ul>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,18 @@ body {
   }
 }
 
+@keyframes waveCrawl25 {
+  to { stroke-dashoffset: -25; }
+}
+
+@keyframes waveCrawl20 {
+  to { stroke-dashoffset: -20; }
+}
+
+@keyframes waveCrawl18 {
+  to { stroke-dashoffset: -18; }
+}
+
 .animate-fade-up {
   animation: fadeUp 0.9s ease both;
 }


### PR DESCRIPTION
## Summary
- Added three CSS `@keyframes` (`waveCrawl25`, `waveCrawl20`, `waveCrawl18`) to `src/index.css` for seamless looping stroke-dashoffset animation
- Applied `strokeDasharray` and inline animation styles to the three decorative SVG wave paths in `src/components/Layout.tsx`
- Each wave animates at a different speed (8s / 13s / 10s) with different dash densities for a parallax depth effect
- Print safety preserved — existing `animation: none !important` in the print media query covers all new animations

## Test Plan
- [ ] Open the site and confirm all three waves are visually crawling/flowing
- [ ] Verify waves animate at noticeably different speeds (top fastest, mid slowest)
- [ ] Confirm animation loops without any visible jump or glitch
- [ ] In DevTools Rendering panel, set CSS media to `print` — waves should go static

🤖 Generated with [Claude Code](https://claude.com/claude-code)